### PR TITLE
Changed defaults for mel spectrogram filters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This codebase provides PyTorch implementation of some librosa functions. The functions can run on GPU. For example, users can extract log mel spectrogram on GPU. The numerical difference of this codebase and librosa is less than 1e-6.
 
 # Install
-```
+```bash
 $ pip install torchlibrosa
 ```
 
@@ -11,7 +11,7 @@ $ pip install torchlibrosa
 
 Here are examples of extracting spectrogram, log mel spectrogram, STFT and ISTFT using torchlibrosa.
 
-```
+```python
 import torch
 import torchlibrosa as tl
 
@@ -37,8 +37,38 @@ y = istft_extractor.forward(real, imag, x.shape[-1])	# (batch_size, samples_num)
 ```
 
 # More examples
-```
+
+```python
 python3 torchlibrosa/stft.py
+```
+
+# Compability to librosa functions
+
+If one you previously used for training cpu-extracted features from librosa, but want to add GPU acceleration during i.e., evaluation, then note that the following code will provide identical features to standard mel spectrograms:
+
+```python
+## Librosa implementation
+import torch
+import torchlibrosa as tl
+
+sample_rate=16000
+win_length=640
+hop_length=320
+n_mels=128
+
+raw_audio = torch.empty(sample_rate).uniform_(-1,1) #Float32 input with normalized scale (-1,1)
+
+#Torchlibrosa feature extractor similar to librosa.feature.melspectrogram()
+feature_extractor = torch.nn.Sequential(
+    tl.stft.Spectrogram(
+        hop_length=hop_length,
+        win_length=win_length,
+    ), tl.stft.LogmelFilterBank(
+        sr=sample_rate,
+        n_mels=n_mels,
+        is_log=False, #Default is true
+    ))
+feature = feature_extractor(raw_audio.unsqueeze(0)) # Shape is (Batch,1,T,N_Mels)
 ```
 
 # Cite


### PR DESCRIPTION
Hey 秋强,
I am a bit late about the pull request, but as I meant to say last week, I would suggest changing the defaults from your filters to be comparable to librosa ones.
I think you have chosen the current defaults (fmin = 50, max = 14000) due to your experiments.
This pull request changes the defaults of fmin=0 and fmax=sr//2. 
It might break some previous code that used your defaults.

Reasons why I think the change is necessary:

For some people, which use librosa as their front-end features, the change would allow them to switch training and evaluation front-end libraries.
For example: Training is done by extracting features normally in librosa, but during the evaluation, where one might need GPU accelerated features, this can be achieved by this code.
For me, this is an actual use-case, since storing raw-audio consumes much more space than extracted log-mel-spectrograms.

I wrote an additional test to check if both extracted (default) features between librosa and torchlibrosa are nearly equal.

Also thanks for the recent talk!

Henri (丁翰林)


