### PR TITLE
Fix bug where ISTFT with device="cuda" and move between devices didn't work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !*.*
 *.pyc
 __pycache__
+.idea

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,4 @@
+librosa>=0.6.0
+numpy
+pytest
+torch

--- a/tests/test_istft.py
+++ b/tests/test_istft.py
@@ -1,0 +1,38 @@
+import pytest
+import torch
+import torch.testing
+from numpy.testing import assert_array_almost_equal
+
+from torchlibrosa import ISTFT, STFT
+
+
+class TestISTFT:
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_move_onnx_compatible_istft_between_devices(self):
+        # Check that the ONNX variant of ISTFT works when initialized with device="cuda"
+        # and that it works as expected when moved to CPU afterwards.
+        length = 16000
+        waveform = torch.rand(1, length, dtype=torch.float32, device="cuda")
+
+        stft = STFT().cuda()
+
+        (real, imag) = stft(waveform)
+        frames_num = real.shape[2]
+
+        istft = ISTFT(
+            onnx=True,
+            frames_num=frames_num,
+            device="cuda",
+        ).cuda()
+
+        waveform_output_cuda = istft(real, imag, length=length)
+
+        # Move to CPU and do the pass there
+        real = real.cpu()
+        imag = imag.cpu()
+        istft = istft.cpu()
+        waveform_output_cpu = istft(real, imag, length=length)
+
+        assert_array_almost_equal(
+            waveform_output_cpu.numpy(), waveform_output_cuda.cpu().numpy(), decimal=5
+        )

--- a/torchlibrosa/stft.py
+++ b/torchlibrosa/stft.py
@@ -167,6 +167,7 @@ class STFT(DFTBase):
         center=True,
         pad_mode="reflect",
         freeze_parameters=True,
+        transpose: bool = True,
     ):
         r"""PyTorch implementation of STFT with Conv1d. The function has the
         same output as librosa.stft.
@@ -247,6 +248,8 @@ class STFT(DFTBase):
             for param in self.parameters():
                 param.requires_grad = False
 
+        self.transpose = transpose
+
     def forward(self, input):
         r"""Calculate STFT of batch of signals.
 
@@ -270,9 +273,10 @@ class STFT(DFTBase):
         imag = self.conv_imag(x)
         # (batch_size, n_fft // 2 + 1, time_steps)
 
-        real = real[:, None, :, :].transpose(2, 3)
-        imag = imag[:, None, :, :].transpose(2, 3)
-        # (batch_size, 1, time_steps, n_fft // 2 + 1)
+        if self.transpose:
+            real = real[:, None, :, :].transpose(2, 3)
+            imag = imag[:, None, :, :].transpose(2, 3)
+            # (batch_size, 1, time_steps, n_fft // 2 + 1)
 
         return real, imag
 

--- a/torchlibrosa/stft.py
+++ b/torchlibrosa/stft.py
@@ -484,13 +484,14 @@ class ISTFT(DFTBase):
         else:
             self.ifft_window_sum = []
 
-    def forward(self, real_stft, imag_stft, length):
+    def forward(self, real_stft, imag_stft, length, transpose: bool = True):
         r"""Calculate inverse STFT.
 
         Args:
-            real_stft: (batch_size, channels=1, time_steps, n_fft // 2 + 1)
-            imag_stft: (batch_size, channels=1, time_steps, n_fft // 2 + 1)
+            real_stft: (batch_size, channels=1, time_steps, n_fft // 2 + 1) if transpose=True else (batch_size, channels=1, n_fft // 2 + 1, time_steps)
+            imag_stft: (batch_size, channels=1, time_steps, n_fft // 2 + 1) if transpose=True else (batch_size, channels=1, n_fft // 2 + 1, time_steps)
             length: int
+            transpose: Whether the last two dims in real_stft and imag_stft need to be swapped
 
         Returns:
             real: (batch_size, data_length), output signals.
@@ -498,8 +499,11 @@ class ISTFT(DFTBase):
         assert real_stft.ndimension() == 4 and imag_stft.ndimension() == 4
         batch_size, _, frames_num, _ = real_stft.shape
 
-        real_stft = real_stft[:, 0, :, :].transpose(1, 2)
-        imag_stft = imag_stft[:, 0, :, :].transpose(1, 2)
+        real_stft = real_stft[:, 0, :, :]
+        imag_stft = imag_stft[:, 0, :, :]
+        if transpose:
+            real_stft = real_stft.transpose(1, 2)
+            imag_stft = imag_stft.transpose(1, 2)
         # (batch_size, n_fft // 2 + 1, time_steps)
 
         # Get full stft representation from spectrum using symmetry attribute.

--- a/torchlibrosa/stft.py
+++ b/torchlibrosa/stft.py
@@ -257,8 +257,11 @@ class STFT(DFTBase):
             real: (batch_size, 1, time_steps, n_fft // 2 + 1)
             imag: (batch_size, 1, time_steps, n_fft // 2 + 1)
         """
-
-        x = input[:, None, :]  # (batch_size, channels_num, data_length)
+        if input.ndim == 2:
+            x = input[:, None, :]  # (batch_size, channels_num, data_length)
+        else:
+            assert input.ndim == 3
+            x = input
 
         if self.center:
             x = F.pad(x, pad=(self.n_fft // 2, self.n_fft // 2), mode=self.pad_mode)

--- a/torchlibrosa/stft.py
+++ b/torchlibrosa/stft.py
@@ -181,6 +181,7 @@ class STFT(DFTBase):
             pad_mode: str, e.g., 'reflect'
             freeze_parameters: bool, set to True to freeze all parameters. Set
                 to False to finetune all parameters.
+            transpose: Whether to swap the last two dimensions before returning.
         """
         super(STFT, self).__init__()
 
@@ -273,9 +274,13 @@ class STFT(DFTBase):
         imag = self.conv_imag(x)
         # (batch_size, n_fft // 2 + 1, time_steps)
 
+        real = real[:, None, :, :]
+        imag = imag[:, None, :, :]
+        # (batch_size, 1, n_fft // 2 + 1, time_steps)
+
         if self.transpose:
-            real = real[:, None, :, :].transpose(2, 3)
-            imag = imag[:, None, :, :].transpose(2, 3)
+            real = real.transpose(2, 3)
+            imag = imag.transpose(2, 3)
             # (batch_size, 1, time_steps, n_fft // 2 + 1)
 
         return real, imag

--- a/torchlibrosa/stft.py
+++ b/torchlibrosa/stft.py
@@ -12,8 +12,7 @@ from torch.nn.parameter import Parameter
 
 class DFTBase(nn.Module):
     def __init__(self):
-        r"""Base class for DFT and IDFT matrix.
-        """
+        r"""Base class for DFT and IDFT matrix."""
         super(DFTBase, self).__init__()
 
     def dft_matrix(self, n):
@@ -68,7 +67,7 @@ class DFT(DFTBase):
 
         if self.norm is None:
             pass
-        elif self.norm == 'ortho':
+        elif self.norm == "ortho":
             z_real /= math.sqrt(self.n)
             z_imag /= math.sqrt(self.n)
 
@@ -84,13 +83,17 @@ class DFT(DFTBase):
             z_real: (n,), real part of output
             z_imag: (n,), imag part of output
         """
-        z_real = torch.matmul(x_real, self.inv_W_real) - torch.matmul(x_imag, self.inv_W_imag)
-        z_imag = torch.matmul(x_imag, self.inv_W_real) + torch.matmul(x_real, self.inv_W_imag)
+        z_real = torch.matmul(x_real, self.inv_W_real) - torch.matmul(
+            x_imag, self.inv_W_imag
+        )
+        z_imag = torch.matmul(x_imag, self.inv_W_real) + torch.matmul(
+            x_real, self.inv_W_imag
+        )
         # shape: (n,)
 
         if self.norm is None:
             z_real /= self.n
-        elif self.norm == 'ortho':
+        elif self.norm == "ortho":
             z_real /= math.sqrt(n)
             z_imag /= math.sqrt(n)
 
@@ -108,13 +111,13 @@ class DFT(DFTBase):
             z_imag: (n // 2 + 1,), imag part of output
         """
         n_rfft = self.n // 2 + 1
-        z_real = torch.matmul(x_real, self.W_real[..., 0 : n_rfft])
-        z_imag = torch.matmul(x_real, self.W_imag[..., 0 : n_rfft])
+        z_real = torch.matmul(x_real, self.W_real[..., 0:n_rfft])
+        z_imag = torch.matmul(x_real, self.W_imag[..., 0:n_rfft])
         # shape: (n // 2 + 1,)
 
         if self.norm is None:
             pass
-        elif self.norm == 'ortho':
+        elif self.norm == "ortho":
             z_real /= math.sqrt(self.n)
             z_imag /= math.sqrt(self.n)
 
@@ -138,23 +141,33 @@ class DFT(DFTBase):
         # shape: (n // 2 + 1,)
 
         x_real = torch.cat((x_real, flip_x_real[..., 1 : n_rfft - 1]), dim=-1)
-        x_imag = torch.cat((x_imag, -1. * flip_x_imag[..., 1 : n_rfft - 1]), dim=-1)
+        x_imag = torch.cat((x_imag, -1.0 * flip_x_imag[..., 1 : n_rfft - 1]), dim=-1)
         # shape: (n,)
 
-        z_real = torch.matmul(x_real, self.inv_W_real) - torch.matmul(x_imag, self.inv_W_imag)
+        z_real = torch.matmul(x_real, self.inv_W_real) - torch.matmul(
+            x_imag, self.inv_W_imag
+        )
         # shape: (n,)
 
         if self.norm is None:
             z_real /= self.n
-        elif self.norm == 'ortho':
+        elif self.norm == "ortho":
             z_real /= math.sqrt(n)
 
         return z_real
 
 
 class STFT(DFTBase):
-    def __init__(self, n_fft=2048, hop_length=None, win_length=None,
-                 window='hann', center=True, pad_mode='reflect', freeze_parameters=True):
+    def __init__(
+        self,
+        n_fft=2048,
+        hop_length=None,
+        win_length=None,
+        window="hann",
+        center=True,
+        pad_mode="reflect",
+        freeze_parameters=True,
+    ):
         r"""PyTorch implementation of STFT with Conv1d. The function has the
         same output as librosa.stft.
 
@@ -170,7 +183,7 @@ class STFT(DFTBase):
         """
         super(STFT, self).__init__()
 
-        assert pad_mode in ['constant', 'reflect']
+        assert pad_mode in ["constant", "reflect"]
 
         self.n_fft = n_fft
         self.hop_length = hop_length
@@ -197,21 +210,37 @@ class STFT(DFTBase):
 
         out_channels = n_fft // 2 + 1
 
-        self.conv_real = nn.Conv1d(in_channels=1, out_channels=out_channels,
-                                   kernel_size=n_fft, stride=self.hop_length, padding=0, dilation=1,
-                                   groups=1, bias=False)
+        self.conv_real = nn.Conv1d(
+            in_channels=1,
+            out_channels=out_channels,
+            kernel_size=n_fft,
+            stride=self.hop_length,
+            padding=0,
+            dilation=1,
+            groups=1,
+            bias=False,
+        )
 
-        self.conv_imag = nn.Conv1d(in_channels=1, out_channels=out_channels,
-                                   kernel_size=n_fft, stride=self.hop_length, padding=0, dilation=1,
-                                   groups=1, bias=False)
+        self.conv_imag = nn.Conv1d(
+            in_channels=1,
+            out_channels=out_channels,
+            kernel_size=n_fft,
+            stride=self.hop_length,
+            padding=0,
+            dilation=1,
+            groups=1,
+            bias=False,
+        )
 
         # Initialize Conv1d weights.
         self.conv_real.weight.data = torch.Tensor(
-            np.real(self.W[:, 0 : out_channels] * fft_window[:, None]).T)[:, None, :]
+            np.real(self.W[:, 0:out_channels] * fft_window[:, None]).T
+        )[:, None, :]
         # (n_fft // 2 + 1, 1, n_fft)
 
         self.conv_imag.weight.data = torch.Tensor(
-            np.imag(self.W[:, 0 : out_channels] * fft_window[:, None]).T)[:, None, :]
+            np.imag(self.W[:, 0:out_channels] * fft_window[:, None]).T
+        )[:, None, :]
         # (n_fft // 2 + 1, 1, n_fft)
 
         if freeze_parameters:
@@ -229,7 +258,7 @@ class STFT(DFTBase):
             imag: (batch_size, 1, time_steps, n_fft // 2 + 1)
         """
 
-        x = input[:, None, :]   # (batch_size, channels_num, data_length)
+        x = input[:, None, :]  # (batch_size, channels_num, data_length)
 
         if self.center:
             x = F.pad(x, pad=(self.n_fft // 2, self.n_fft // 2), mode=self.pad_mode)
@@ -265,9 +294,19 @@ def magphase(real, imag):
 
 
 class ISTFT(DFTBase):
-    def __init__(self, n_fft=2048, hop_length=None, win_length=None,
-                 window='hann', center=True, pad_mode='reflect', freeze_parameters=True,
-                 onnx=False, frames_num=None, device=None):
+    def __init__(
+        self,
+        n_fft=2048,
+        hop_length=None,
+        win_length=None,
+        window="hann",
+        center=True,
+        pad_mode="reflect",
+        freeze_parameters=True,
+        onnx=False,
+        frames_num=None,
+        device=None,
+    ):
         """PyTorch implementation of ISTFT with Conv1d. The function has the
         same output as librosa.istft.
 
@@ -288,7 +327,7 @@ class ISTFT(DFTBase):
         """
         super(ISTFT, self).__init__()
 
-        assert pad_mode in ['constant', 'reflect']
+        assert pad_mode in ["constant", "reflect"]
 
         if not onnx:
             assert frames_num is None, "When onnx=False, frames_num must be None!"
@@ -325,46 +364,64 @@ class ISTFT(DFTBase):
                 param.requires_grad = False
 
     def init_real_imag_conv(self, device):
-        r"""Initialize Conv1d for calculating real and imag part of DFT.
-        """
+        r"""Initialize Conv1d for calculating real and imag part of DFT."""
         self.W = self.idft_matrix(self.n_fft) / self.n_fft
 
-        self.conv_real = nn.Conv1d(in_channels=self.n_fft, out_channels=self.n_fft,
-                                   kernel_size=1, stride=1, padding=0, dilation=1,
-                                   groups=1, bias=False)
+        self.conv_real = nn.Conv1d(
+            in_channels=self.n_fft,
+            out_channels=self.n_fft,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dilation=1,
+            groups=1,
+            bias=False,
+        )
 
-        self.conv_imag = nn.Conv1d(in_channels=self.n_fft, out_channels=self.n_fft,
-                                   kernel_size=1, stride=1, padding=0, dilation=1,
-                                   groups=1, bias=False)
+        self.conv_imag = nn.Conv1d(
+            in_channels=self.n_fft,
+            out_channels=self.n_fft,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dilation=1,
+            groups=1,
+            bias=False,
+        )
 
-        ifft_window = librosa.filters.get_window(self.window, self.win_length, fftbins=True)
+        ifft_window = librosa.filters.get_window(
+            self.window, self.win_length, fftbins=True
+        )
         # (win_length,)
 
         # Pad the window to n_fft
         ifft_window = librosa.util.pad_center(ifft_window, self.n_fft)
 
         self.conv_real.weight.data = torch.Tensor(
-            np.real(self.W * ifft_window[None, :]).T)[:, :, None]
+            np.real(self.W * ifft_window[None, :]).T
+        )[:, :, None]
         self.conv_real = self.conv_real.to(device)
         # (n_fft // 2 + 1, 1, n_fft)
 
         self.conv_imag.weight.data = torch.Tensor(
-            np.imag(self.W * ifft_window[None, :]).T)[:, :, None]
+            np.imag(self.W * ifft_window[None, :]).T
+        )[:, :, None]
         self.conv_imag = self.conv_imag.to(device)
         # (n_fft // 2 + 1, 1, n_fft)
 
     def init_overlap_add_window(self):
-        r"""Initialize overlap add window for reconstruct time domain signals.
-        """
+        r"""Initialize overlap add window for reconstruct time domain signals."""
 
-        ola_window = librosa.filters.get_window(self.window, self.win_length, fftbins=True)
+        ola_window = librosa.filters.get_window(
+            self.window, self.win_length, fftbins=True
+        )
         # (win_length,)
 
         ola_window = librosa.util.normalize(ola_window, norm=None) ** 2
         ola_window = librosa.util.pad_center(ola_window, self.n_fft)
         ola_window = torch.Tensor(ola_window)
 
-        self.register_buffer('ola_window', ola_window)
+        self.register_buffer("ola_window", ola_window)
         # (win_length,)
 
     def init_onnx_modules(self, frames_num, device):
@@ -377,28 +434,41 @@ class ISTFT(DFTBase):
 
         # Use Conv1d to implement torch.flip(), because torch.flip() is not
         # supported by ONNX.
-        self.reverse = nn.Conv1d(in_channels=self.n_fft // 2 + 1,
-                                 out_channels=self.n_fft // 2 - 1, kernel_size=1, bias=False)
+        self.reverse = nn.Conv1d(
+            in_channels=self.n_fft // 2 + 1,
+            out_channels=self.n_fft // 2 - 1,
+            kernel_size=1,
+            bias=False,
+        )
 
         tmp = np.zeros((self.n_fft // 2 - 1, self.n_fft // 2 + 1, 1))
-        tmp[:, 1 : -1, 0] = np.array(np.eye(self.n_fft // 2 - 1)[::-1])
+        tmp[:, 1:-1, 0] = np.array(np.eye(self.n_fft // 2 - 1)[::-1])
         self.reverse.weight.data = torch.Tensor(tmp)
         self.reverse = self.reverse.to(torch.device(device))
         # (n_fft // 2 - 1, n_fft // 2 + 1, 1)
 
         # Use nn.ConvTranspose2d to implement torch.nn.functional.fold(),
         # because torch.nn.functional.fold() is not supported by ONNX.
-        self.overlap_add = nn.ConvTranspose2d(in_channels=self.n_fft,
-                                              out_channels=1, kernel_size=(self.n_fft, 1), stride=(self.hop_length, 1), bias=False)
+        self.overlap_add = nn.ConvTranspose2d(
+            in_channels=self.n_fft,
+            out_channels=1,
+            kernel_size=(self.n_fft, 1),
+            stride=(self.hop_length, 1),
+            bias=False,
+        )
 
-        self.overlap_add.weight.data = torch.Tensor(np.eye(self.n_fft)[:, None, :, None])
+        self.overlap_add.weight.data = torch.Tensor(
+            np.eye(self.n_fft)[:, None, :, None]
+        )
         self.overlap_add = self.overlap_add.to(torch.device(device))
         # (n_fft, 1, n_fft, 1)
 
         if frames_num:
             # Pre-calculate overlap-add window sum for reconstructing signals
             # when using ONNX.
-            self.ifft_window_sum = self._get_ifft_window_sum_onnx(frames_num, device)
+            self.register_buffer(
+                "ifft_window_sum", self._get_ifft_window_sum_onnx(frames_num, device)
+            )
         else:
             self.ifft_window_sum = []
 
@@ -422,7 +492,9 @@ class ISTFT(DFTBase):
 
         # Get full stft representation from spectrum using symmetry attribute.
         if self.onnx:
-            full_real_stft, full_imag_stft = self._get_full_stft_onnx(real_stft, imag_stft)
+            full_real_stft, full_imag_stft = self._get_full_stft_onnx(
+                real_stft, imag_stft
+            )
         else:
             full_real_stft, full_imag_stft = self._get_full_stft(real_stft, imag_stft)
         # full_real_stft: (batch_size, n_fft, time_steps)
@@ -455,8 +527,12 @@ class ISTFT(DFTBase):
             full_real_stft: (batch_size, n_fft, time_steps)
             full_imag_stft: (batch_size, n_fft, time_steps)
         """
-        full_real_stft = torch.cat((real_stft, torch.flip(real_stft[:, 1 : -1, :], dims=[1])), dim=1)
-        full_imag_stft = torch.cat((imag_stft, - torch.flip(imag_stft[:, 1 : -1, :], dims=[1])), dim=1)
+        full_real_stft = torch.cat(
+            (real_stft, torch.flip(real_stft[:, 1:-1, :], dims=[1])), dim=1
+        )
+        full_imag_stft = torch.cat(
+            (imag_stft, -torch.flip(imag_stft[:, 1:-1, :], dims=[1])), dim=1
+        )
 
         return full_real_stft, full_imag_stft
 
@@ -476,7 +552,7 @@ class ISTFT(DFTBase):
 
         # Implement torch.flip() with Conv1d.
         full_real_stft = torch.cat((real_stft, self.reverse(real_stft)), dim=1)
-        full_imag_stft = torch.cat((imag_stft, - self.reverse(imag_stft)), dim=1)
+        full_imag_stft = torch.cat((imag_stft, -self.reverse(imag_stft)), dim=1)
 
         return full_real_stft, full_imag_stft
 
@@ -497,8 +573,12 @@ class ISTFT(DFTBase):
         # Overlap-add signals in frames to signals. Ref:
         # asteroid_filterbanks.torch_stft_fb.torch_stft_fb() from
         # https://github.com/asteroid-team/asteroid-filterbanks
-        y = torch.nn.functional.fold(input=s_real, output_size=(1, output_samples),
-                                     kernel_size=(1, self.win_length), stride=(1, self.hop_length))
+        y = torch.nn.functional.fold(
+            input=s_real,
+            output_size=(1, output_samples),
+            kernel_size=(1, self.win_length),
+            stride=(1, self.hop_length),
+        )
         # (batch_size, 1, 1, audio_samples,)
 
         y = y[:, 0, 0, :]
@@ -539,9 +619,12 @@ class ISTFT(DFTBase):
         window_matrix = self.ola_window[None, :, None].repeat(1, 1, frames_num)
         # (batch_size, win_length, time_steps)
 
-        ifft_window_sum = F.fold(input=window_matrix,
-                                 output_size=(1, output_samples), kernel_size=(1, self.win_length),
-                                 stride=(1, self.hop_length))
+        ifft_window_sum = F.fold(
+            input=window_matrix,
+            output_size=(1, output_samples),
+            kernel_size=(1, self.win_length),
+            stride=(1, self.hop_length),
+        )
         # (1, 1, 1, audio_samples)
 
         ifft_window_sum = ifft_window_sum.squeeze()
@@ -573,7 +656,10 @@ class ISTFT(DFTBase):
         if len(self.ifft_window_sum) != y.shape[1]:
             device = s_real.device
 
-            self.ifft_window_sum = self._get_ifft_window_sum_onnx(frames_num, device)
+            self.register_buffer(
+                "ifft_window_sum", self._get_ifft_window_sum_onnx(frames_num, device)
+            )
+
             # (audio_samples,)
 
         # Use torch.clamp() to prevent from underflow to make sure all
@@ -598,12 +684,16 @@ class ISTFT(DFTBase):
             ifft_window_sum: (audio_samples,)
         """
 
-        ifft_window_sum = librosa.filters.window_sumsquare(window=self.window,
-                                                           n_frames=frames_num, win_length=self.win_length, n_fft=self.n_fft,
-                                                           hop_length=self.hop_length)
+        ifft_window_sum = librosa.filters.window_sumsquare(
+            window=self.window,
+            n_frames=frames_num,
+            win_length=self.win_length,
+            n_fft=self.n_fft,
+            hop_length=self.hop_length,
+        )
         # (audio_samples,)
 
-        ifft_window_sum = torch.Tensor(ifft_window_sum)
+        ifft_window_sum = torch.from_numpy(ifft_window_sum)
 
         if device:
             ifft_window_sum = ifft_window_sum.to(device)
@@ -636,9 +726,17 @@ class ISTFT(DFTBase):
 
 
 class Spectrogram(nn.Module):
-    def __init__(self, n_fft=2048, hop_length=None, win_length=None,
-                 window='hann', center=True, pad_mode='reflect', power=2.0,
-                 freeze_parameters=True):
+    def __init__(
+        self,
+        n_fft=2048,
+        hop_length=None,
+        win_length=None,
+        window="hann",
+        center=True,
+        pad_mode="reflect",
+        power=2.0,
+        freeze_parameters=True,
+    ):
         r"""Calculate spectrogram using pytorch. The STFT is implemented with
         Conv1d. The function has the same output of librosa.stft
         """
@@ -646,9 +744,15 @@ class Spectrogram(nn.Module):
 
         self.power = power
 
-        self.stft = STFT(n_fft=n_fft, hop_length=hop_length,
-                         win_length=win_length, window=window, center=center,
-                         pad_mode=pad_mode, freeze_parameters=True)
+        self.stft = STFT(
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
     def forward(self, input):
         r"""Calculate spectrogram of input signals.
@@ -673,8 +777,19 @@ class Spectrogram(nn.Module):
 
 
 class LogmelFilterBank(nn.Module):
-    def __init__(self, sr=22050, n_fft=2048, n_mels=64, fmin=0.0, fmax=None,
-                 is_log=True, ref=1.0, amin=1e-10, top_db=80.0, freeze_parameters=True):
+    def __init__(
+        self,
+        sr=22050,
+        n_fft=2048,
+        n_mels=64,
+        fmin=0.0,
+        fmax=None,
+        is_log=True,
+        ref=1.0,
+        amin=1e-10,
+        top_db=80.0,
+        freeze_parameters=True,
+    ):
         r"""Calculate logmel spectrogram using pytorch. The mel filter bank is
         the pytorch implementation of as librosa.filters.mel
         """
@@ -685,10 +800,11 @@ class LogmelFilterBank(nn.Module):
         self.amin = amin
         self.top_db = top_db
         if fmax == None:
-            fmax = sr//2
+            fmax = sr // 2
 
-        self.melW = librosa.filters.mel(sr=sr, n_fft=n_fft, n_mels=n_mels,
-                                        fmin=fmin, fmax=fmax).T
+        self.melW = librosa.filters.mel(
+            sr=sr, n_fft=n_fft, n_mels=n_mels, fmin=fmin, fmax=fmax
+        ).T
         # (n_fft // 2 + 1, mel_bins)
 
         self.melW = nn.Parameter(torch.Tensor(self.melW))
@@ -719,7 +835,6 @@ class LogmelFilterBank(nn.Module):
 
         return output
 
-
     def power_to_db(self, input):
         r"""Power to db, this function is the pytorch implementation of
         librosa.power_to_lb
@@ -730,8 +845,12 @@ class LogmelFilterBank(nn.Module):
 
         if self.top_db is not None:
             if self.top_db < 0:
-                raise librosa.util.exceptions.ParameterError('top_db must be non-negative')
-            log_spec = torch.clamp(log_spec, min=log_spec.max().item() - self.top_db, max=np.inf)
+                raise librosa.util.exceptions.ParameterError(
+                    "top_db must be non-negative"
+                )
+            log_spec = torch.clamp(
+                log_spec, min=log_spec.max().item() - self.top_db, max=np.inf
+            )
 
         return log_spec
 
@@ -743,11 +862,18 @@ class Enframe(nn.Module):
         """
         super(Enframe, self).__init__()
 
-        self.enframe_conv = nn.Conv1d(in_channels=1, out_channels=frame_length,
-                                      kernel_size=frame_length, stride=hop_length,
-                                      padding=0, bias=False)
+        self.enframe_conv = nn.Conv1d(
+            in_channels=1,
+            out_channels=frame_length,
+            kernel_size=frame_length,
+            stride=hop_length,
+            padding=0,
+            bias=False,
+        )
 
-        self.enframe_conv.weight.data = torch.Tensor(torch.eye(frame_length)[:, None, :])
+        self.enframe_conv.weight.data = torch.Tensor(
+            torch.eye(frame_length)[:, None, :]
+        )
         self.enframe_conv.weight.requires_grad = False
 
     def forward(self, input):
@@ -761,7 +887,6 @@ class Enframe(nn.Module):
         output = self.enframe_conv(input[:, None, :])
         return output
 
-
     def power_to_db(self, input):
         r"""Power to db, this function is the pytorch implementation of
         librosa.power_to_lb.
@@ -772,8 +897,12 @@ class Enframe(nn.Module):
 
         if self.top_db is not None:
             if self.top_db < 0:
-                raise librosa.util.exceptions.ParameterError('top_db must be non-negative')
-            log_spec = torch.clamp(log_spec, min=log_spec.max() - self.top_db, max=np.inf)
+                raise librosa.util.exceptions.ParameterError(
+                    "top_db must be non-negative"
+                )
+            log_spec = torch.clamp(
+                log_spec, min=log_spec.max() - self.top_db, max=np.inf
+            )
 
         return log_spec
 
@@ -782,8 +911,8 @@ class Scalar(nn.Module):
     def __init__(self, scalar, freeze_parameters):
         super(Scalar, self).__init__()
 
-        self.scalar_mean = Parameter(torch.Tensor(scalar['mean']))
-        self.scalar_std = Parameter(torch.Tensor(scalar['std']))
+        self.scalar_mean = Parameter(torch.Tensor(scalar["mean"]))
+        self.scalar_std = Parameter(torch.Tensor(scalar["std"]))
 
         if freeze_parameters:
             for param in self.parameters():
@@ -801,9 +930,9 @@ def debug(select, device):
         device: 'cpu' | 'cuda'
     """
 
-    if select == 'dft':
+    if select == "dft":
         n = 10
-        norm = None     # None | 'ortho'
+        norm = None  # None | 'ortho'
         np.random.seed(0)
 
         # Data
@@ -823,8 +952,10 @@ def debug(select, device):
         pt_rdft = obj.rdft(pt_data)
         pt_irdft = obj.irdft(pt_rdft[0], pt_rdft[1])
 
-        print('Comparing librosa and pytorch implementation of DFT. All numbers '
-              'below should be close to 0.')
+        print(
+            "Comparing librosa and pytorch implementation of DFT. All numbers "
+            "below should be close to 0."
+        )
         print(np.mean((np.abs(np.real(np_fft) - pt_dft[0].cpu().numpy()))))
         print(np.mean((np.abs(np.imag(np_fft) - pt_dft[1].cpu().numpy()))))
 
@@ -836,7 +967,7 @@ def debug(select, device):
 
         print(np.mean(np.abs(np_data - pt_irdft.cpu().numpy())))
 
-    elif select == 'stft':
+    elif select == "stft":
         device = torch.device(device)
         np.random.seed(0)
 
@@ -846,54 +977,86 @@ def debug(select, device):
         n_fft = 2048
         hop_length = 512
         win_length = 2048
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
 
         # Data
         np_data = np.random.uniform(-1, 1, data_length)
         pt_data = torch.Tensor(np_data).to(device)
 
         # Numpy stft matrix
-        np_stft_matrix = librosa.stft(y=np_data, n_fft=n_fft,
-                                      hop_length=hop_length, window=window, center=center).T
+        np_stft_matrix = librosa.stft(
+            y=np_data, n_fft=n_fft, hop_length=hop_length, window=window, center=center
+        ).T
 
         # Pytorch stft matrix
-        pt_stft_extractor = STFT(n_fft=n_fft, hop_length=hop_length,
-                                 win_length=win_length, window=window, center=center, pad_mode=pad_mode,
-                                 freeze_parameters=True)
+        pt_stft_extractor = STFT(
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         pt_stft_extractor.to(device)
 
         (pt_stft_real, pt_stft_imag) = pt_stft_extractor.forward(pt_data[None, :])
 
-        print('Comparing librosa and pytorch implementation of STFT & ISTFT. \
-            All numbers below should be close to 0.')
-        print(np.mean(np.abs(np.real(np_stft_matrix) - pt_stft_real.data.cpu().numpy()[0, 0])))
-        print(np.mean(np.abs(np.imag(np_stft_matrix) - pt_stft_imag.data.cpu().numpy()[0, 0])))
+        print(
+            "Comparing librosa and pytorch implementation of STFT & ISTFT. \
+            All numbers below should be close to 0."
+        )
+        print(
+            np.mean(
+                np.abs(np.real(np_stft_matrix) - pt_stft_real.data.cpu().numpy()[0, 0])
+            )
+        )
+        print(
+            np.mean(
+                np.abs(np.imag(np_stft_matrix) - pt_stft_imag.data.cpu().numpy()[0, 0])
+            )
+        )
 
         # Numpy istft
-        np_istft_s = librosa.istft(stft_matrix=np_stft_matrix.T,
-                                   hop_length=hop_length, window=window, center=center, length=data_length)
+        np_istft_s = librosa.istft(
+            stft_matrix=np_stft_matrix.T,
+            hop_length=hop_length,
+            window=window,
+            center=center,
+            length=data_length,
+        )
 
         # Pytorch istft
-        pt_istft_extractor = ISTFT(n_fft=n_fft, hop_length=hop_length,
-                                   win_length=win_length, window=window, center=center, pad_mode=pad_mode,
-                                   freeze_parameters=True)
+        pt_istft_extractor = ISTFT(
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
         pt_istft_extractor.to(device)
 
         # Recover from real and imag part
-        pt_istft_s = pt_istft_extractor.forward(pt_stft_real, pt_stft_imag, data_length)[0, :]
+        pt_istft_s = pt_istft_extractor.forward(
+            pt_stft_real, pt_stft_imag, data_length
+        )[0, :]
 
         # Recover from magnitude and phase
         (pt_stft_mag, cos, sin) = magphase(pt_stft_real, pt_stft_imag)
-        pt_istft_s2 = pt_istft_extractor.forward(pt_stft_mag * cos, pt_stft_mag * sin, data_length)[0, :]
+        pt_istft_s2 = pt_istft_extractor.forward(
+            pt_stft_mag * cos, pt_stft_mag * sin, data_length
+        )[0, :]
 
         print(np.mean(np.abs(np_istft_s - pt_istft_s.data.cpu().numpy())))
         print(np.mean(np.abs(np_data - pt_istft_s.data.cpu().numpy())))
         print(np.mean(np.abs(np_data - pt_istft_s2.data.cpu().numpy())))
 
-    elif select == 'logmel':
+    elif select == "logmel":
         dtype = np.complex64
         device = torch.device(device)
         np.random.seed(0)
@@ -904,13 +1067,13 @@ def debug(select, device):
         n_fft = 2048
         hop_length = 512
         win_length = 2048
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
 
         # Mel parameters (the same as librosa.feature.melspectrogram)
         n_mels = 128
-        fmin = 0.
+        fmin = 0.0
         fmax = sample_rate / 2.0
 
         # Power to db parameters (the same as default settings of librosa.power_to_db
@@ -922,60 +1085,112 @@ def debug(select, device):
         np_data = np.random.uniform(-1, 1, data_length)
         pt_data = torch.Tensor(np_data).to(device)
 
-        print('Comparing librosa and pytorch implementation of logmel '
-              'spectrogram. All numbers below should be close to 0.')
+        print(
+            "Comparing librosa and pytorch implementation of logmel "
+            "spectrogram. All numbers below should be close to 0."
+        )
 
         # Numpy librosa
-        np_stft_matrix = librosa.stft(y=np_data, n_fft=n_fft, hop_length=hop_length,
-                                      win_length=win_length, window=window, center=center, dtype=dtype,
-                                      pad_mode=pad_mode)
+        np_stft_matrix = librosa.stft(
+            y=np_data,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=center,
+            dtype=dtype,
+            pad_mode=pad_mode,
+        )
 
         np_pad = np.pad(np_data, int(n_fft // 2), mode=pad_mode)
 
-        np_melW = librosa.filters.mel(sr=sample_rate, n_fft=n_fft, n_mels=n_mels,
-                                      fmin=fmin, fmax=fmax).T
+        np_melW = librosa.filters.mel(
+            sr=sample_rate, n_fft=n_fft, n_mels=n_mels, fmin=fmin, fmax=fmax
+        ).T
 
         np_mel_spectrogram = np.dot(np.abs(np_stft_matrix.T) ** 2, np_melW)
 
         np_logmel_spectrogram = librosa.power_to_db(
-            np_mel_spectrogram, ref=ref, amin=amin, top_db=top_db)
+            np_mel_spectrogram, ref=ref, amin=amin, top_db=top_db
+        )
 
         # Pytorch
-        stft_extractor = STFT(n_fft=n_fft, hop_length=hop_length,
-                              win_length=win_length, window=window, center=center, pad_mode=pad_mode,
-                              freeze_parameters=True)
+        stft_extractor = STFT(
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
-        logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=n_fft,
-                                            n_mels=n_mels, fmin=fmin, fmax=fmax, ref=ref, amin=amin,
-                                            top_db=top_db, freeze_parameters=True)
+        logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=n_fft,
+            n_mels=n_mels,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         stft_extractor.to(device)
         logmel_extractor.to(device)
 
-        pt_pad = F.pad(pt_data[None, None, :], pad=(n_fft // 2, n_fft // 2), mode=pad_mode)[0, 0]
+        pt_pad = F.pad(
+            pt_data[None, None, :], pad=(n_fft // 2, n_fft // 2), mode=pad_mode
+        )[0, 0]
         print(np.mean(np.abs(np_pad - pt_pad.cpu().numpy())))
 
         pt_stft_matrix_real = stft_extractor.conv_real(pt_pad[None, None, :])[0]
         pt_stft_matrix_imag = stft_extractor.conv_imag(pt_pad[None, None, :])[0]
-        print(np.mean(np.abs(np.real(np_stft_matrix) - pt_stft_matrix_real.data.cpu().numpy())))
-        print(np.mean(np.abs(np.imag(np_stft_matrix) - pt_stft_matrix_imag.data.cpu().numpy())))
+        print(
+            np.mean(
+                np.abs(np.real(np_stft_matrix) - pt_stft_matrix_real.data.cpu().numpy())
+            )
+        )
+        print(
+            np.mean(
+                np.abs(np.imag(np_stft_matrix) - pt_stft_matrix_imag.data.cpu().numpy())
+            )
+        )
 
         # Spectrogram
-        spectrogram_extractor = Spectrogram(n_fft=n_fft, hop_length=hop_length,
-                                            win_length=win_length, window=window, center=center, pad_mode=pad_mode,
-                                            freeze_parameters=True)
+        spectrogram_extractor = Spectrogram(
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         spectrogram_extractor.to(device)
 
         pt_spectrogram = spectrogram_extractor.forward(pt_data[None, :])
         pt_mel_spectrogram = torch.matmul(pt_spectrogram, logmel_extractor.melW)
-        print(np.mean(np.abs(np_mel_spectrogram - pt_mel_spectrogram.data.cpu().numpy()[0, 0])))
+        print(
+            np.mean(
+                np.abs(np_mel_spectrogram - pt_mel_spectrogram.data.cpu().numpy()[0, 0])
+            )
+        )
 
         # Log mel spectrogram
         pt_logmel_spectrogram = logmel_extractor.forward(pt_spectrogram)
-        print(np.mean(np.abs(np_logmel_spectrogram - pt_logmel_spectrogram[0, 0].data.cpu().numpy())))
+        print(
+            np.mean(
+                np.abs(
+                    np_logmel_spectrogram
+                    - pt_logmel_spectrogram[0, 0].data.cpu().numpy()
+                )
+            )
+        )
 
-    elif select == 'enframe':
+    elif select == "enframe":
         device = torch.device(device)
         np.random.seed(0)
 
@@ -989,12 +1204,15 @@ def debug(select, device):
         np_data = np.random.uniform(-1, 1, data_length)
         pt_data = torch.Tensor(np_data).to(device)
 
-        print('Comparing librosa and pytorch implementation of '
-              'librosa.util.frame. All numbers below should be close to 0.')
+        print(
+            "Comparing librosa and pytorch implementation of "
+            "librosa.util.frame. All numbers below should be close to 0."
+        )
 
         # Numpy librosa
-        np_frames = librosa.util.frame(np_data, frame_length=win_length,
-                                       hop_length=hop_length)
+        np_frames = librosa.util.frame(
+            np_data, frame_length=win_length, hop_length=hop_length
+        )
 
         # Pytorch
         pt_frame_extractor = Enframe(frame_length=win_length, hop_length=hop_length)
@@ -1003,7 +1221,7 @@ def debug(select, device):
         pt_frames = pt_frame_extractor(pt_data[None, :])
         print(np.mean(np.abs(np_frames - pt_frames.data.cpu().numpy())))
 
-    elif select == 'default':
+    elif select == "default":
         device = torch.device(device)
         np.random.seed(0)
 
@@ -1024,39 +1242,42 @@ def debug(select, device):
             Spectrogram(
                 hop_length=hop_length,
                 win_length=win_length,
-            ), LogmelFilterBank(
+            ),
+            LogmelFilterBank(
                 sr=sample_rate,
                 n_mels=n_mels,
-                is_log=False, #Default is true
-            ))
+                is_log=False,  # Default is true
+            ),
+        )
 
         feature_extractor.to(device)
 
         print(
-            'Comparing default mel spectrogram from librosa to the pytorch implementation.'
+            "Comparing default mel spectrogram from librosa to the pytorch implementation."
         )
 
         # Numpy librosa
-        np_melspect = librosa.feature.melspectrogram(np_data,
-                                                     hop_length=hop_length,
-                                                     sr=sample_rate,
-                                                     win_length=win_length,
-                                                     n_mels=n_mels).T
-        #Pytorch
+        np_melspect = librosa.feature.melspectrogram(
+            np_data,
+            hop_length=hop_length,
+            sr=sample_rate,
+            win_length=win_length,
+            n_mels=n_mels,
+        ).T
+        # Pytorch
         pt_melspect = feature_extractor(pt_data[None, :]).squeeze()
-        passed = np.allclose(pt_melspect.data.to('cpu').numpy(), np_melspect)
+        passed = np.allclose(pt_melspect.data.to("cpu").numpy(), np_melspect)
         print(f"Passed? {passed}")
 
 
+if __name__ == "__main__":
 
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--device', type=str, default='cpu', choices=['cpu', 'cuda'])
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("--device", type=str, default="cpu", choices=["cpu", "cuda"])
     args = parser.parse_args()
 
     device = args.device
-    norm = None     # None | 'ortho'
+    norm = None  # None | 'ortho'
     np.random.seed(0)
 
     # Spectrogram parameters (the same as librosa.stft)
@@ -1065,13 +1286,13 @@ if __name__ == '__main__':
     n_fft = 2048
     hop_length = 512
     win_length = 2048
-    window = 'hann'
+    window = "hann"
     center = True
-    pad_mode = 'reflect'
+    pad_mode = "reflect"
 
     # Mel parameters (the same as librosa.feature.melspectrogram)
     n_mels = 128
-    fmin = 0.
+    fmin = 0.0
     fmax = sample_rate / 2.0
 
     # Power to db parameters (the same as default settings of librosa.power_to_db
@@ -1084,13 +1305,27 @@ if __name__ == '__main__':
     pt_data = torch.Tensor(np_data).to(device)
 
     # Pytorch
-    spectrogram_extractor = Spectrogram(n_fft=n_fft, hop_length=hop_length,
-                                        win_length=win_length, window=window, center=center, pad_mode=pad_mode,
-                                        freeze_parameters=True)
+    spectrogram_extractor = Spectrogram(
+        n_fft=n_fft,
+        hop_length=hop_length,
+        win_length=win_length,
+        window=window,
+        center=center,
+        pad_mode=pad_mode,
+        freeze_parameters=True,
+    )
 
-    logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=n_fft,
-                                        n_mels=n_mels, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db,
-                                        freeze_parameters=True)
+    logmel_extractor = LogmelFilterBank(
+        sr=sample_rate,
+        n_fft=n_fft,
+        n_mels=n_mels,
+        fmin=fmin,
+        fmax=fmax,
+        ref=ref,
+        amin=amin,
+        top_db=top_db,
+        freeze_parameters=True,
+    )
 
     spectrogram_extractor.to(device)
     logmel_extractor.to(device)
@@ -1103,13 +1338,15 @@ if __name__ == '__main__':
 
     # Uncomment for debug
     if True:
-        debug(select='dft', device=device)
-        debug(select='stft', device=device)
-        debug(select='logmel', device=device)
-        debug(select='enframe', device=device)
+        debug(select="dft", device=device)
+        debug(select="stft", device=device)
+        debug(select="logmel", device=device)
+        debug(select="enframe", device=device)
 
         try:
-            debug(select='default', device=device)
+            debug(select="default", device=device)
         except:
-            raise Exception('Torchlibrosa does support librosa>=0.6.0, for \
-                comparison with librosa, please use librosa>=0.7.0!')
+            raise Exception(
+                "Torchlibrosa does support librosa>=0.6.0, for \
+                comparison with librosa, please use librosa>=0.7.0!"
+            )

--- a/torchlibrosa/stft.py
+++ b/torchlibrosa/stft.py
@@ -286,7 +286,7 @@ def magphase(real, imag):
         cos: tensor, cosine of phases of signals
         sin: tensor, sine of phases of signals
     """
-    mag = (real ** 2 + imag ** 2) ** 0.5
+    mag = (real**2 + imag**2) ** 0.5
     cos = real / torch.clamp(mag, 1e-10, np.inf)
     sin = imag / torch.clamp(mag, 1e-10, np.inf)
 
@@ -766,7 +766,7 @@ class Spectrogram(nn.Module):
         (real, imag) = self.stft.forward(input)
         # (batch_size, n_fft // 2 + 1, time_steps)
 
-        spectrogram = real ** 2 + imag ** 2
+        spectrogram = real**2 + imag**2
 
         if self.power == 2.0:
             pass
@@ -987,7 +987,12 @@ def debug(select, device):
 
         # Numpy stft matrix
         np_stft_matrix = librosa.stft(
-            y=np_data, n_fft=n_fft, hop_length=hop_length, window=window, center=center
+            y=np_data,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
         ).T
 
         # Pytorch stft matrix
@@ -1006,8 +1011,8 @@ def debug(select, device):
         (pt_stft_real, pt_stft_imag) = pt_stft_extractor.forward(pt_data[None, :])
 
         print(
-            "Comparing librosa and pytorch implementation of STFT & ISTFT. \
-            All numbers below should be close to 0."
+            "Comparing librosa and pytorch implementation of STFT & ISTFT.            "
+            " All numbers below should be close to 0."
         )
         print(
             np.mean(
@@ -1253,7 +1258,8 @@ def debug(select, device):
         feature_extractor.to(device)
 
         print(
-            "Comparing default mel spectrogram from librosa to the pytorch implementation."
+            "Comparing default mel spectrogram from librosa to the pytorch"
+            " implementation."
         )
 
         # Numpy librosa
@@ -1271,7 +1277,6 @@ def debug(select, device):
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(description="")
     parser.add_argument("--device", type=str, default="cpu", choices=["cpu", "cuda"])
     args = parser.parse_args()
@@ -1347,6 +1352,6 @@ if __name__ == "__main__":
             debug(select="default", device=device)
         except:
             raise Exception(
-                "Torchlibrosa does support librosa>=0.6.0, for \
-                comparison with librosa, please use librosa>=0.7.0!"
+                "Torchlibrosa does support librosa>=0.6.0, for                "
+                " comparison with librosa, please use librosa>=0.7.0!"
             )

--- a/torchlibrosa/stft.py
+++ b/torchlibrosa/stft.py
@@ -1235,6 +1235,7 @@ def debug(select, device):
         data_length = sample_rate * 1
         hop_length = 512
         win_length = 2048
+        pad_mode = "reflect"
 
         # Mel parameters (the same as librosa.feature.melspectrogram)
         n_mels = 128
@@ -1269,6 +1270,7 @@ def debug(select, device):
             sr=sample_rate,
             win_length=win_length,
             n_mels=n_mels,
+            pad_mode=pad_mode,
         ).T
         # Pytorch
         pt_melspect = feature_extractor(pt_data[None, :]).squeeze()

--- a/torchlibrosa/stft.py
+++ b/torchlibrosa/stft.py
@@ -203,7 +203,7 @@ class STFT(DFTBase):
         fft_window = librosa.filters.get_window(window, self.win_length, fftbins=True)
 
         # Pad the window out to n_fft size.
-        fft_window = librosa.util.pad_center(fft_window, n_fft)
+        fft_window = librosa.util.pad_center(data=fft_window, size=n_fft)
 
         # DFT & IDFT matrix.
         self.W = self.dft_matrix(n_fft)
@@ -395,7 +395,7 @@ class ISTFT(DFTBase):
         # (win_length,)
 
         # Pad the window to n_fft
-        ifft_window = librosa.util.pad_center(ifft_window, self.n_fft)
+        ifft_window = librosa.util.pad_center(data=ifft_window, size=self.n_fft)
 
         self.conv_real.weight.data = torch.Tensor(
             np.real(self.W * ifft_window[None, :]).T
@@ -418,7 +418,7 @@ class ISTFT(DFTBase):
         # (win_length,)
 
         ola_window = librosa.util.normalize(ola_window, norm=None) ** 2
-        ola_window = librosa.util.pad_center(ola_window, self.n_fft)
+        ola_window = librosa.util.pad_center(data=ola_window, size=self.n_fft)
         ola_window = torch.Tensor(ola_window)
 
         self.register_buffer("ola_window", ola_window)


### PR DESCRIPTION
I've added a test that previously failed*, but passes with the few patches I applied

\* `E       RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same`