### PR TITLE
Fix Typo in setup.py Description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="0.1.0",
     author="Qiuqiang Kong",
     author_email="qiuqiangkong@gmail.com",
-    description="PyTorch implemention of part of librosa functions.",
+    description="PyTorch implementation of part of librosa functions.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/qiuqiangkong/torchlibrosa",


### PR DESCRIPTION
This PR fixes a small typo in `setup.py` where `implemention` is corrected to `implementation`, ensuring that tools like `codespell` do not complain when tracking a `poetry.lock` file.
